### PR TITLE
fixed actions box on detail page

### DIFF
--- a/ui/documents/templates/semantic-ui/documents/Sidebar.jinja
+++ b/ui/documents/templates/semantic-ui/documents/Sidebar.jinja
@@ -1,5 +1,5 @@
 {#def metadata, record, extra_context #}
-{% if record.request_types or record.requests or record.links.edit_html%}
+{% if record.expanded.request_types or record.expanded.requests or record.links.edit_html%}
 <section class="ui segment" aria-label='{{ _("Actions") }}'>
 <h2 class="ui small header detail-sidebar-header">{{ _("Actions") }}</h2>
 {% if record.links.edit_html%}


### PR DESCRIPTION
@mirekys Ahoj, I made an error in the previous merge, so that requests box would not appear on detail page. This is the fix. Please take a look.