### PR TITLE
pragerdom/ntk-72-opravit-workflow-generic-community-restricted-files

### DIFF
--- a/common/workflows/generic_community.py
+++ b/common/workflows/generic_community.py
@@ -50,9 +50,10 @@ class GenericCommunityWorkflowPermissions(CommunityDefaultWorkflowPermissions):
             then_=[
                 IfRestricted(
                     "files",
-                    # Only the owner sees files from embargoed/restricted records
                     then_=[
                         RecordOwners(),
+                        PrimaryCommunityRole("curator"),
+                        PrimaryCommunityRole("owner"),
                     ],
                     else_=[AnyUser()],
                 )


### PR DESCRIPTION
Based on feedback, make owner and curator of generic community be able to read restricted files in addition to their owner.