### PR TITLE
Class name resulting in error during import

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -581,7 +581,7 @@ GLOBAL_SEARCH_MODELS = [
     {
         "model_service": "documents.services.records.service.DocumentsService",
         "service_config": "documents.services.records.config.DocumentsServiceConfig",
-        "ui_resource_config": "ui.documents.DocumentsResourceConfig",
+        "ui_resource_config": "ui.documents.DocumentsUIResourceConfig",
         "api_resource_config": "documents.resources.records.config.DocumentsResourceConfig",
     }
 ]

--- a/ui/documents/__init__.py
+++ b/ui/documents/__init__.py
@@ -20,7 +20,7 @@ from ui.documents.components.allowed_file_extension_ui_component import (
 )
 
 
-class DocumentsResourceConfig(RecordsUIResourceConfig):
+class DocumentsUIResourceConfig(RecordsUIResourceConfig):
     template_folder = "templates"
     url_prefix = "/docs/"
     blueprint_name = "documents"
@@ -60,10 +60,10 @@ class DocumentsResourceConfig(RecordsUIResourceConfig):
         ]
 
 
-class DocumentsResource(RecordsUIResource):
+class DocumentsUIResource(RecordsUIResource):
     pass
 
 
 def create_blueprint(app):
     """Register blueprint for this resource."""
-    return DocumentsResource(DocumentsResourceConfig()).as_blueprint()
+    return DocumentsUIResource(DocumentsUIResourceConfig()).as_blueprint()


### PR DESCRIPTION
Because class name did not have UI in it, it was causing errors during imports in certain libraries (for example oarepo-rdm).

I have tested app with the applied changes (dashboard, communities, creating requests etc) and everything should be working