### PR TITLE
A new permission for searching all records

### DIFF
--- a/common/workflows/default.py
+++ b/common/workflows/default.py
@@ -122,6 +122,10 @@ class DefaultWorkflowPermissions(CommunityDefaultWorkflowPermissions):
         ),
     ]
 
+    # note: can_read_draft and can_read are not mutually exclusive (they test IfInState)
+    # so we can just add them together
+    can_search_all_records = can_read_draft + can_read
+
     # who can read a deleted record (on an /api/documents/ url)
     # this is strange, but taken from RDM
     can_read_deleted = [

--- a/common/workflows/generic_community.py
+++ b/common/workflows/generic_community.py
@@ -115,6 +115,10 @@ class GenericCommunityWorkflowPermissions(CommunityDefaultWorkflowPermissions):
         ),
     ]
 
+    # note: can_read_draft and can_read are not mutually exclusive (they test IfInState)
+    # so we can just add them together
+    can_search_all_records = can_read_draft + can_read
+
     # who can read a deleted record (on an /api/documents/ url)
     # this is strange, but taken from RDM
     can_read_deleted = [

--- a/common/workflows/restricted.py
+++ b/common/workflows/restricted.py
@@ -122,6 +122,10 @@ class RestrictedWorkflowPermissions(CommunityDefaultWorkflowPermissions):
         ),
     ]
 
+    # note: can_read_draft and can_read are not mutually exclusive (they test IfInState)
+    # so we can just add them together
+    can_search_all_records = can_read_draft + can_read
+
     # who can read a deleted record (on an /api/documents/ url)
     # this is strange, but taken from RDM
     can_read_deleted = [


### PR DESCRIPTION
We can search all records (regardless if they are published or not) on API level. This PR adds a permission for this to docs.