### PR TITLE
Adds URL field to CSL JSON schema

### DIFF
--- a/common/resources/citations/schema.py
+++ b/common/resources/citations/schema.py
@@ -160,11 +160,11 @@ class CSLJSONSchema(Schema):
     
     def get_url(self, obj):
         """Get URL."""
-        objectIds = obj["metadata"].get("objectIdentifiers", [])
-        doi = next((o["identifier"] for o in objectIds if o["scheme"].lower() == "doi"), None)
+        object_ids = obj["metadata"].get("objectIdentifiers", [])
+        doi = next((o["identifier"] for o in object_ids if o["scheme"].lower() == "doi"), None)
         url = None
         if doi:
             url = f"https://doi.org/{doi}"
         else:
-            url = next((o["url"] for o in objectIds if o["scheme"].lower() != "doi"), None)
+            url = next((o["url"] for o in object_ids if o["scheme"].lower() != "doi"), None)
         return url if url else missing

--- a/common/resources/citations/schema.py
+++ b/common/resources/citations/schema.py
@@ -93,7 +93,8 @@ class CSLJSONSchema(Schema):
     issued = fields.Method("get_issued")
     language = fields.Method("get_language")
     version = SanitizedUnicode(attribute="metadata.version")
-    publisher = fields.Method("get_publisher") 
+    publisher = fields.Method("get_publisher")
+    URL = fields.Method("get_url")
     
     def get_title(self, obj):
         """Get title."""
@@ -156,3 +157,14 @@ class CSLJSONSchema(Schema):
             return language_id
 
         return missing
+    
+    def get_url(self, obj):
+        """Get URL."""
+        objectIds = obj["metadata"].get("objectIdentifiers", [])
+        doi = next((o["identifier"] for o in objectIds if o["scheme"].lower() == "doi"), None)
+        url = None
+        if doi:
+            url = f"https://doi.org/{doi}"
+        else:
+            url = next((o["url"] for o in objectIds if o["scheme"].lower() != "doi"), None)
+        return url if url else missing

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -946,3 +946,9 @@ MAIL_SUPPRESS_SEND = env.get("INVENIO_MAIL_SUPPRESS_SEND", True)
 
 NOTIFICATIONS_SETTINGS_VIEW_FUNCTION = notification_settings
 ACCOUNTS_USER_PREFERENCES_SCHEMA = UserPreferencesNotificationsSchema()
+
+CITATION_STYLES = [
+    { "style": "iso690-author-date-cs", "label": _("ČSN ISO 690") },
+    { "style": "bibtex", "label": _("BibTeX") }
+]
+CITATION_STYLES_DEFAULT = "iso690-author-date-cs"

--- a/ui/documents/templates/semantic-ui/documents/Sidebar.jinja
+++ b/ui/documents/templates/semantic-ui/documents/Sidebar.jinja
@@ -41,13 +41,6 @@
 <RecordVersions record={record} is_preview={is_preview} />
 {% endif %}
 
-{% set citation_settings = {
-  "styles": [
-    { "style": "iso690-author-date-cs", "label": "ČSN ISO 690" },
-    { "style": "bibtex", "label": "BibTeX" }
-  ],
-  "defaultStyle": "iso690-author-date-cs"
-} %}
-<RecordCitations record={record} citation_settings={citation_settings} />
+<RecordCitations record={record} styles={config.get("CITATION_STYLES")} defaultStyle={config.get("CITATION_STYLES_DEFAULT")} />
 <RecordExport record={record} metadata={metadata} extra_context={extra_context}/>
 


### PR DESCRIPTION
- Adds a URL field to the CSL JSON schema, which is populated based on DOI or other object identifiers present in the metadata. This allows retrieval of a URL associated with the cited object, prioritizing DOI-based URLs.
- Also extracts citation settings to invenio.cfg