### PR TITLE
Fixes for the following RT tickets:

### DIFF
--- a/common/workflows/vocabularies.py
+++ b/common/workflows/vocabularies.py
@@ -7,3 +7,4 @@ class DocsVocabulariesPermissionPolicy(VocabulariesPermissionPolicy):
     can_update = VocabulariesPermissionPolicy.can_update + [Administration()]
     can_edit = VocabulariesPermissionPolicy.can_update + [Administration()]
     can_view_deposit_page = VocabulariesPermissionPolicy.can_create + [Administration()]
+    can_delete = VocabulariesPermissionPolicy.can_delete + [Administration()]

--- a/documents/services/records/schema.py
+++ b/documents/services/records/schema.py
@@ -27,6 +27,21 @@ class LocalNRDocumentMetadataSchema(NRDocumentMetadataSchema):
         validate=[ma.validate.Length(min=1)],
     )
 
+    def load(self, data, **kwargs):
+        """Remove @v from relations before loading, so that new values will be loaded from vocabulary."""
+
+        def remove_relations_version(d):
+            if isinstance(d, dict):
+                d.pop("@v", None)
+                for v in d.values():
+                    remove_relations_version(v)
+            elif isinstance(d, list):
+                for v in d:
+                    remove_relations_version(v)
+
+        remove_relations_version(data)
+        return super().load(data, **kwargs)
+
 
 class GeneratedParentSchema(RDMWorkflowParentSchema):
     """"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 oarepo[s3,rdm]==12.2.31
-cachetools==6.2.6
+cachetools==7.0.0
 deepmerge==2.0
 et-xmlfile==2.0.0
 flask-babelex==0.9.4
@@ -10,7 +10,7 @@ json5==0.13.0
 langcodes==3.5.1
 levenshtein==0.27.3
 marshmallow-i18n-messages==0.1.1
-nr-metadata==2.0.80
+nr-metadata==2.0.81
 nr-oaipmh-harvesters==1.0.71
 nr-vocabularies==2.1.23
 oarepo-citations==1.0.2
@@ -20,11 +20,11 @@ oarepo-doi==3.0.2
 oarepo-glitchtip==1.1.1
 oarepo-global-search==1.0.45
 oarepo-oai-pmh-harvester==5.0.11
-oarepo-oidc-einfra==1.3.4
+oarepo-oidc-einfra==1.3.6
 oarepo-published-service==1.0.3
 oarepo-rdm==0.6.1
 oarepo-requests==2.5.8
-oarepo-runtime==1.10.4
+oarepo-runtime==1.10.5
 oarepo-ui==5.2.89
 oarepo-vocabularies==2.2.6
 oarepo-workflows==1.2.1


### PR DESCRIPTION
https://rt.cesnet.cz/rt/Ticket/Display.html?id=1499518

Other issues not reported via RT:

* Ability to remove vocabulary item: This is required by NTK but is a dangerous operation, that should be used with a lot of consideration as it can break repository integrity. Only usable with API, user needs to be in administration role.

* Ability to remove community - leaves groups in Perun, modifies perun capabilities to prevent further syncing